### PR TITLE
fix: consider cards length on change cards array

### DIFF
--- a/src/components/CardsSwipe/index.tsx
+++ b/src/components/CardsSwipe/index.tsx
@@ -278,7 +278,7 @@ const CardsSwipe = forwardRef(
             {renderCard(cards[secondIndex])}
           </CardWrap>
         ) : null}
-        {index >= 0 ? (
+        {index >= 0 && cards.length > 0 ? (
           <SwipePan
             {...{
               onSnap: onCardSwiped,


### PR DESCRIPTION
Problem:

- Render Cards Swipe successfully with a filled array
- Navigate to another screen
- Change the source of CardsSwipe cards, from store data or whatever

Expected behavior:
If there are no more items in the array render no more cards, and not render any card at least

Current behavior:
Keeps rendering the last card with a null item, causes crashes and errors

Fix:
In the render method of SwipePan with index>0 also check cards.length>0 logic