### PR TITLE
fix: modify to Extrapolate.CLAMP with default value

### DIFF
--- a/src/components/CardsSwipe/index.tsx
+++ b/src/components/CardsSwipe/index.tsx
@@ -16,6 +16,7 @@ import Animated, {
   withTiming,
   runOnJS,
   withDelay,
+  Extrapolate,
 } from 'react-native-reanimated';
 
 import SwipePan, { SWIPE_DIRECTION } from '../SwipePan';
@@ -243,7 +244,7 @@ const CardsSwipe = forwardRef(
         x.value,
         [-horizontalThreshold, -0.01, 0, 0.01, horizontalThreshold],
         [1, lowerCardZoom, lowerCardZoom, lowerCardZoom, 1],
-        Animated.Extrapolate.CLAMP
+        Extrapolate?.CLAMP ?? 'clamp'
       );
 
       return {


### PR DESCRIPTION
### Summary

- Encountered ReanimatedError: Cannot read property 'CLAMP' of undefined with latest reanimated
- Use `Extrapolate` directly instead of `Animated`
- Add default value `??` for safer approach

Close #19 [ReanimatedError: Cannot read property 'CLAMP' of undefined](https://github.com/tarasvakulka/react-native-cards-swipe/issues/19#top)